### PR TITLE
Removed echo -e for portability issues

### DIFF
--- a/stub.sh
+++ b/stub.sh
@@ -99,7 +99,7 @@ stub_and_eval() {
   fi
 
   # Create the stub.
-  eval "$(printf "${cmd}() {\n  __stub_call \"${cmd}\" \$@\n  $2\n}")"
+  eval "$( printf "%s" "${cmd}() {  __stub_call \"${cmd}\" \$@;  $2;}")"
 }
 
 


### PR DESCRIPTION
The echo -e caused a few portability issues on some of the machines I tried to use stub on, so I changed it to printf which is much more portable.
