### PR TITLE
Changed increment in __stub_register() not to return non 0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ update: update_test-runner.sh update_assert.sh
 test/assert.sh:
 	echo "fetching assert.sh..." && \
 	curl -s -L -o test/assert.sh \
-		https://raw.github.com/lehmannro/assert.sh/v1.0.2/assert.sh
+		https://raw.github.com/lehmannro/assert.sh/v1.1/assert.sh
 
 remove_assert.sh:
 	( \

--- a/stub.sh
+++ b/stub.sh
@@ -401,7 +401,7 @@ __stub_register() {
   eval "STUB_${STUB_NEXT_INDEX}_CALLS=()"
 
   # Increment stub count.
-  ((STUB_NEXT_INDEX++))
+  ((++STUB_NEXT_INDEX))
 }
 
 # Private: Cleans out and removes a stub's call list, and removes stub from

--- a/test/__stub_register.test.sh
+++ b/test/__stub_register.test.sh
@@ -6,7 +6,7 @@ source "test-helper.sh"
 #
 
 # Sets up stub index, stub call list, and adds stub to index.
-__stub_register "uname"
+__stub_register "uname" || assert_raises "false"
 __stub_register "top"
 assert 'echo ${STUB_INDEX[@]}' 'uname=0 top=1'
 assert 'echo ${STUB_INDEX[0]}' 'uname=0'


### PR DESCRIPTION
Changed the style of incrementation in __stub_register() to "++STUB_NEXT_INDEX" from "STUB_NEXT_INDEX++" not to fail the test cases under the "set -e" environment.
Due to this change, assert.sh that had behave similar manner was also updated.